### PR TITLE
Create ATIS Movie Speed Up

### DIFF
--- a/ATIS - Formerly ALMS/ATIS Movie Speed Up
+++ b/ATIS - Formerly ALMS/ATIS Movie Speed Up
@@ -1,0 +1,8 @@
+All of the ATIS Trainings I've done so far are contained in an object named cp.movie
+
+This has an attributed labeled "speed" which lets you speed up the playback of the movie.
+
+Setting this value:
+cp.movie.speed = 10000
+
+Allows you to just keep clicking the next slide button.


### PR DESCRIPTION
ATIS cp.movie.speed value change

It's a simple script to skip the ATIS courses I've done so far.

"cp.movie.speed" controls the playback of the video player.
The default value is 1
A value of 10000 (or more, you get the idea) allows for instant playback and moving to the next slide.